### PR TITLE
Readme.md: Add FAQ and answer on why Author Bio and pic moves due to responsive design

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If there is only one author on your site, you probably want to set the Header Im
 
 First you need to enable **Multi-Author Mode** in *Dashboard → Appearance → Customizer → General Options* . With Multi-Author Mode enabled, the theme Header Image (*Dashboard → Appearance → Header Image*) will be placed in the top-left corner on all Single pages.
 
-### Why is my Author Bio and picture at the top of my home page and not on the side? (Or below a blog post?)
+### Why is my Author Bio and picture at the top of my home page (or below a blog post) and not on the side?
 
 Independent Publisher is a *responsive* theme, which fits the size of your browser depending on the size of your screen.  If you are on a computer, making your browser window wider will automatically move the Author Bio and picture to the side instead of at the top on your homepage or at the bottom of a blog post.
 


### PR DESCRIPTION
Add a question and answer on why the Author Bio and pic moves from the side to the top of the homepage or bottom of a blog post depending on the size of the browser window open.  I can also add screenshots if needed, but didn't think they were.
