### PR TITLE
Check for ACF and a specific ACF field and display if possible.

### DIFF
--- a/content-single.php
+++ b/content-single.php
@@ -16,7 +16,7 @@
 			echo independent_publisher_entry_meta_author_prefix() . ' ';
 		}
 		independent_publisher_posted_author() ?></span>
-		<?php if ( get_field('independent_publisher_primary_category') ) { // check a custom field named 'independent_publisher_primary_category'
+		<?php if ( get_field('independent_publisher_primary_category') ) { // check for a custom field named 'independent_publisher_primary_category'
         	echo independent_publisher_entry_meta_category_prefix() . ' ' . get_field('independent_publisher_primary_category'); // show the primary category as set in ACF
       	} else if ( independent_publisher_categorized_blog() ) {
         	echo independent_publisher_entry_meta_category_prefix() . ' ' . independent_publisher_post_categories( '', true );


### PR DESCRIPTION
I've been using this setup to allow me to choose which category is shown when viewing a single post. ACF could be setup in various ways, but as long as the field is named `primary_category`, and it's not a file field, this should work.

If ACF and the `primary_category` ACF field don't exist (ie: the plugin isn't enabled or hasn't been configured), we fall back to the original category display.

Thought others may like this. I'll have a blog post about my exact setup later on today.
