### PR TITLE
Make sure no primary category set with ACF.

### DIFF
--- a/content-single.php
+++ b/content-single.php
@@ -19,7 +19,7 @@
 		independent_publisher_posted_author() ?></span>
 		<?php if ( get_post_meta( get_the_ID(), 'independent_publisher_primary_category', true ) ) { // check for a custom field named 'independent_publisher_primary_category'
             echo independent_publisher_entry_meta_category_prefix() . ' ' . get_post_meta( get_the_ID(), 'independent_publisher_primary_category', true ); // show the primary category as set in ACF
-      	} else if ( independent_publisher_categorized_blog() ) {
+      	} else if ( independent_publisher_categorized_blog() && !get_field('independent_publisher_primary_category') ) {
         	   echo independent_publisher_entry_meta_category_prefix() . ' ' . independent_publisher_post_categories( '', true );
       	} ?>
 			<span class="entry-title-meta-post-date">


### PR DESCRIPTION
Add a check to make sure there's no primary category set with ACF. Without this additional check, the theme doesn't display the primary category, always doing this:

``` php
echo independent_publisher_entry_meta_category_prefix() . ' ' . independent_publisher_post_categories( '', true );
```
