### PR TITLE
Fix an XSS in independent_publisher_replytocom()

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1052,7 +1052,7 @@ function independent_publisher_post_classes() {
  */
 function independent_publisher_replytocom() {
 	if ( isset( $_GET['replytocom'] ) ) {
-		$replytocom_comment_id = $_GET['replytocom'];
+		$replytocom_comment_id = intval($_GET['replytocom']);
 		$replytocom_post_id    = get_the_ID();
 		?>
 		<script type="text/javascript">


### PR DESCRIPTION
There's a bug that enables a cross-site scripting vulnerability in independent_publisher_replytocom(). If a post page is viewed with something like `?replytocom=42<fnord/>` appended to the URL the `<fnord/>` will be output verbatim into the resulting HTML, which could end very badly, if more evil HTML code was inserted.

The shortest fix is to just cast the ID to integer, since it's a number, and that will remove any injected code. In general though: Every time you `echo` in PHP, you should be absolutely certain that nothing bad can happen. There may be other instances of this in the code, I didn't look and only found this one by accident.