### PR TITLE
Escaped Translated Output using esc_html_e()

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -7,7 +7,7 @@
  */
 ?>
 <form method="get" id="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>" role="search">
-	<label for="s" class="screen-reader-text"><?php _e( 'Search', 'independent-publisher' ); ?></label>
+	<label for="s" class="screen-reader-text"><?php esc_html_e( 'Search', 'independent-publisher' ); ?></label>
 	<input type="text" class="field" name="s" value="<?php echo esc_attr( get_search_query() ); ?>" id="s" placeholder="<?php esc_attr_e( 'Search &hellip;', 'independent-publisher' ); ?>" />
 	<input type="submit" class="submit" name="submit" id="searchsubmit" value="<?php esc_attr_e( 'Search', 'independent-publisher' ); ?>" />
 </form>


### PR DESCRIPTION
https://codex.wordpress.org/Function_Reference/esc_attr_e

_e() does not escape it's output for html