### PR TITLE
Enhanced Comment form: check if the function exists everywhere.

### DIFF
--- a/inc/plugin-support.php
+++ b/inc/plugin-support.php
@@ -60,7 +60,10 @@ endif;
  * When the Disqus Commenting System is active and enabled, don't load our comment form enhancements
  */
 include_once( ABSPATH . 'wp-admin/includes/plugin.php' ); // Required to use is_plugin_active() here
-if ( is_plugin_active( 'disqus-comment-system/disqus.php' ) ) :
+if (
+	is_plugin_active( 'disqus-comment-system/disqus.php' )
+	&& ! function_exists( 'independent_publisher_enhanced_comment_form' )
+) :
 	if ( get_option( 'disqus_active' ) !== '0' ) {
 		function independent_publisher_enhanced_comment_form() {
 			return;
@@ -71,7 +74,11 @@ endif;
 /*
  * When JetPack Comments is enabled, don't load our comment form enhancements
  */
-if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'comments' ) ) {
+if (
+	class_exists( 'Jetpack' )
+	&& Jetpack::is_module_active( 'comments' )
+	&& ! function_exists( 'independent_publisher_enhanced_comment_form' )
+) {
 	function independent_publisher_enhanced_comment_form() {
 		return;
 	}


### PR DESCRIPTION
In #232, I suggested checking if the `independent_publisher_enhanced_comment_form()` function
existed, to allow child themes to overwrite the default function.

For this to work in all cases, we need to do the same in other places where the function is loaded in the parent theme.