### PR TITLE
Made sure pagination information is always displayed.

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -673,13 +673,7 @@ if ( !function_exists( 'independent_publisher_search_stats' ) ):
 		$current_page_num = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 		$pagination_info  = '';
 
-		/**
-		 * Only show pagination info when there is more than 1 page
-		 */
-		if ( $total_pages > 1 ) {
-			$pagination_info = sprintf( __( 'this is page <strong>%1$s</strong> of <strong>%2$s</strong>', 'independent-publisher' ), number_format_i18n( $current_page_num ), number_format_i18n( $total_pages ) );
-		}
-
+		$pagination_info = sprintf( __( 'this is page <strong>%1$s</strong> of <strong>%2$s</strong>', 'independent-publisher' ), number_format_i18n( $current_page_num ), number_format_i18n( $total_pages ) );
 		$stats_text = sprintf( _n( 'Found one search result for <strong>%2$s</strong>.', 'Found %1$s search results for <strong>%2$s</strong> (%3$s).', $total, 'independent-publisher' ), number_format_i18n( $total ), get_search_query(), $pagination_info );
 
 		return wpautop( $stats_text );
@@ -704,13 +698,8 @@ if ( !function_exists( 'independent_publisher_taxonomy_archive_stats' ) ):
 		$pagination_info  = '';
 		$stats_text       = '';
 
-		/**
-		 * Only show pagination info when there is more than 1 page
-		 */
-		if ( $total_pages > 1 ) {
-			$pagination_info = sprintf( __( 'this is page <strong>%1$s</strong> of <strong>%2$s</strong>', 'independent-publisher' ), number_format_i18n( $current_page_num ), number_format_i18n( $total_pages ) );
-		}
-
+		$pagination_info = sprintf( __( 'this is page <strong>%1$s</strong> of <strong>%2$s</strong>', 'independent-publisher' ), number_format_i18n( $current_page_num ), number_format_i18n( $total_pages ) );
+		
 		if ( $taxonomy === 'category' ) {
 			$stats_text = sprintf( _n( 'There is one post filed in <strong>%2$s</strong>.', 'There are %1$s posts filed in <strong>%2$s</strong> (%3$s).', $total, 'independent-publisher' ), number_format_i18n( $total ), single_term_title( '', false ), $pagination_info );
 		} elseif ( $taxonomy === 'post_tag' ) {
@@ -733,13 +722,8 @@ if ( !function_exists( 'independent_publisher_date_archive_description' ) ):
 		$pagination_info   = '';
 		$date_archive_meta = '';
 
-		/**
-		 * Only show pagination info when there is more than 1 page
-		 */
-		if ( $total_pages > 1 ) {
-			$pagination_info = sprintf( __( 'this is page <strong>%1$s</strong> of <strong>%2$s</strong>', 'independent-publisher' ), number_format_i18n( $current_page_num ), number_format_i18n( $total_pages ) );
-		}
-
+		$pagination_info = sprintf( __( 'this is page <strong>%1$s</strong> of <strong>%2$s</strong>', 'independent-publisher' ), number_format_i18n( $current_page_num ), number_format_i18n( $total_pages ) );
+		
 		/**
 		 * Only proceed if we're on the first page and the description has not been overridden via independent_publisher_custom_date_archive_meta
 		 */


### PR DESCRIPTION
Made sure pagination information is always displayed no matter how many pages are in a given set of paginated content (tags, categories, search results, archive). Previously, the pagination information was not shown if the content only spanned one page.

I've tested this with tags, archives, and searches, but not categories because I don't have any test data available.

Fixes #249.