### PR TITLE
Add proper link post type

### DIFF
--- a/content-link.php
+++ b/content-link.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @package Independent Publisher
+ * @since   Independent Publisher 1.0
+ */
+?>
+<article id="post-<?php the_ID(); ?>" <?php independent_publisher_post_classes(); ?>>
+  <header class="entry-header">
+    <h1 class="entry-title p-name">
+      <a target="_blank" href="<?php echo independent_publisher_get_link_url(); ?>" title="<?php echo independent_publisher_post_link_title(); ?>" rel="bookmark"><?php the_title(); ?></a>
+    </h1>
+  </header>
+  <!-- .entry-header -->
+
+  <div class="<?php echo independent_publisher_show_excerpt() ? 'entry-summary e-summary' : 'entry-content e-content'; ?>">
+
+    <?php if ( independent_publisher_show_excerpt() ) : ?>
+
+      <?php the_excerpt(); ?>
+
+    <?php else : ?>
+
+      <?php the_content( independent_publisher_continue_reading_text() ); ?>
+
+        <?php wp_link_pages(
+          array(
+            'before' => '<div class="page-links">' . __( 'Pages:', 'independent-publisher' ),
+            'after'  => '</div>'
+          )
+        ); ?>
+
+    <?php endif; ?>
+  </div>
+  <!-- .entry-content -->
+
+  <footer class="entry-meta">
+
+    <?php
+    /* Show author name and post categories only when post type == post AND
+     * we're not showing the first post full content
+     */
+    ?>
+    <?php if ( 'post' == get_post_type() && independent_publisher_is_not_first_post_full_content() ) : // post type == post conditional hides category text for Pages on Search ?>
+      <?php independent_publisher_posted_author_cats() ?>
+    <?php endif; ?>
+
+    <?php /* Show post date when show post date option enabled */
+    ?>
+    <?php if ( independent_publisher_show_date_entry_meta() ) : ?>
+      <?php echo independent_publisher_get_post_date() ?>
+    <?php endif; ?>
+
+    <?php
+    /* Show post word count when post is not password-protected AND
+     * this is a Standard post format AND
+     * post word count option enabled AND
+     * we're not showing the first post full content
+     */
+    ?>
+    <?php if ( !post_password_required() && false === get_post_format() && independent_publisher_show_post_word_count() && independent_publisher_is_not_first_post_full_content() ) : ?>
+      <?php echo independent_publisher_get_post_word_count() ?>
+    <?php endif; ?>
+
+    <?php $separator = apply_filters( 'independent_publisher_entry_meta_separator', '|' ); ?>
+
+    <?php /* Show webmentions link only when post is not password-protected AND pings open AND there are mentions on this post */ ?>
+    <?php if ( !post_password_required() && pings_open() && independent_publisher_comment_count_mentions() ) : ?>
+      <?php $mention_count = independent_publisher_comment_count_mentions(); ?>
+      <?php $mention_label = (independent_publisher_comment_count_mentions() > 1 ? __( 'Webmentions', 'independent-publisher' ) : __( 'Webmention', 'independent-publisher' ) ); ?>
+      <span class="mentions-link"><a href="<?php the_permalink(); ?>#webmentions"><?php echo $mention_count . ' ' . $mention_label; ?></a></span><span class="sep"><?php echo (comments_open() && !independent_publisher_hide_comments()) ?  ' '.$separator : '' ?></span>
+    <?php endif; ?>
+
+    <?php /* Show comments link only when post is not password-protected AND comments are enabled on this post */ ?>
+    <?php if ( !post_password_required() && comments_open() && !independent_publisher_hide_comments() ) : ?>
+      <span class="comments-link"><?php comments_popup_link( __( 'Comment', 'independent-publisher' ), __( '1 Comment', 'independent-publisher' ), __( '% Comments', 'independent-publisher' ) ); ?></span>
+    <?php endif; ?>
+
+    <?php edit_post_link( __( 'Edit', 'independent-publisher' ), '<span class="sep"> ' . $separator . ' </span> <span class="edit-link">', '</span>' ); ?>
+
+  </footer>
+  <!-- .entry-meta -->
+</article><!-- #post-<?php the_ID(); ?> -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -854,3 +854,21 @@ if ( ! function_exists( 'independent_publisher_show_related_tags' ) ) :
 		endif;
 	}
 endif;
+
+if ( ! function_exists( 'independent_publisher_get_link_url' ) ) :
+  /**
+   * Return the post URL.
+   *
+   * Falls back to the post permalink if no URL is found in the post.
+   *
+   * @since Independent Publisher 1.8
+   *
+   * @see get_url_in_content()
+   *
+   * @return string The Link format URL.
+   */
+  function independent_publisher_get_link_url() {
+  	$has_url = get_url_in_content( get_the_content() );
+    return $has_url ? $has_url : apply_filters( 'the_permalink', get_permalink() );
+  }
+endif;


### PR DESCRIPTION
Add and enable proper link post type. Added content-link.php -- which is
a reduced content.php -- that now uses the post title to link to the
first URL that is used in the post content. The link is opened in a new
browser tab/window. The function that extracts the first URL from the
post content was borrowed from the twenty fifteen link.

Fixes: #278