### PR TITLE
Fix bugs for rtl-style.css

### DIFF
--- a/css/rtl-style.css
+++ b/css/rtl-style.css
@@ -2748,7 +2748,7 @@ table th {
 
 	.site-header,
 	.single-column-layout .site-header {
-		text-align: left;
+		text-align: right;
 	}
 
 	.site-main article.sticky {

--- a/css/rtl-style.css
+++ b/css/rtl-style.css
@@ -1926,7 +1926,7 @@ article.first-post {
 	margin-top: 0;
 	margin-bottom: 30px;
 	width: 160px;
-	position: relative;
+	position: static;
 	margin-right: -220px;
 	text-align: left;
 }
@@ -2161,7 +2161,7 @@ table th {
 	float: none;
 	display: block;
 	width: 100%;
-	position: relative;
+	position: static;
 }
 
 .single-column-layout.single .site-header {

--- a/functions.php
+++ b/functions.php
@@ -265,7 +265,7 @@ if ( ! function_exists( 'independent_publisher_stylesheet_rtl' ) ) :
 	 * Enqueue RTL stylesheet
 	 */
 	function independent_publisher_stylesheet_rtl() {
-		wp_enqueue_style( 'independent-publisher-style', get_template_directory() . '/css/rtl-style.css' );
+		wp_enqueue_style( 'independent-publisher-style', get_template_directory_uri() . '/css/rtl-style.css' );
 	}
 endif;
 


### PR DESCRIPTION
`wp_enqueue_style( 'independent-publisher-style', get_template_directory() . '/css/rtl-style.css' );` is causing rtl-style.css not to load because of wrong path error as `get_template_directory()` will use the server path for the template folder. Changed to `get_template_directory_uri()`