### PR TITLE
Set custom sizes attribute for content / full-width featured images

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -733,6 +733,38 @@ function independent_publisher_post_has_post_cover_title() {
 	return false; // Default
 }
 
+if ( ! function_exists( 'independent_publisher_content_image_sizes_attr' ) ) :
+	/**
+	 * Set a more accurate sizes attribute for content images
+	 */
+	function independent_publisher_content_image_sizes_attr( $sizes, $size ) {
+		$width = $size[0];
+
+		if ( 700 <= $width ) {
+			$sizes = '(max-width: 500px) calc(100vw - 40px), (max-width: 780px) calc(100vw - 80px), 700px';
+		}
+
+		return $sizes;
+	}
+endif;
+
+add_filter( 'wp_calculate_image_sizes', 'independent_publisher_content_image_sizes_attr', 10, 2 );
+
+if ( ! function_exists( 'independent_publisher_full_width_featured_image_sizes_attr' ) ) :
+	/**
+	 * Set a more accurate sizes attribute for full width featured images
+	 */
+	function independent_publisher_full_width_featured_image_sizes_attr( $attr, $attachment, $size ) {
+		if ( independent_publisher_has_full_width_featured_image() ) {
+			$attr['sizes'] = '100vw';
+		}
+
+		return $attr;
+	}
+endif;
+
+add_filter( 'wp_get_attachment_image_attributes', 'independent_publisher_full_width_featured_image_sizes_attr', 10, 3 );
+
 
 /**
  * Returns true if Enable Page Load Progress Bar option is enabled


### PR DESCRIPTION
This works with the built-in [responsive image functionality added in WordPress 4.4](https://make.wordpress.org/core/2015/11/10/responsive-images-in-wordpress-4-4/), to allow browsers to download smaller versions of content images and full-width featured images when possible.

These changes are modelled after similar code in the [Twenty Sixteen](https://github.com/WordPress/twentysixteen/blob/6f1f3affcd3dbd2a1bccfefbf7b0e3a47d39873b/functions.php#L360-L405) and [Twenty Seventeen](https://github.com/WordPress/twentyseventeen/blob/fa09211f54799dd03e8acda9d19108aafb1a8c77/functions.php#L324-L370) themes. (Current code for these themes are slightly different than their GitHub versions, but its much easier to link to the GitHub versions :laughing:)