### PR TITLE
Use responsive images

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,17 @@ function __social_menu_eae_encode_emails( $objects, $args ) {
 
 ### How can I use a Full Size Image for the Post Cover?
 
-By default, the theme will use a maximum of `700x700` pixels for the Post Cover image. You can override this and use the full image size by adding the following to your Child Theme's `functions.php` file:
+In WordPress 4.4 or later, the theme will use WordPress' default maximum width for responsive images of `1600px` for the Post Cover image. You can override this and use a larger limit, or remove the limit entirely, by adding the following to your Child Theme's `functions.php` file:
+
+```php
+function __custom_independent_publisher_max_srcset_image_width( $max_width ) {
+    return 2000; // or return false to disable the limit
+}
+
+add_filter( 'max_srcset_image_width', '__custom_independent_publisher_max_srcset_image_width' );
+```
+
+In WordPress versions earlier than 4.4, the theme will use a maximum of `700x700` pixels for the Post Cover image by default. You can override this and use the full image size by adding the following to your Child Theme's `functions.php` file:
 
 ```php
 function __custom_independent_publisher_full_width_featured_image_size() {

--- a/functions.php
+++ b/functions.php
@@ -737,6 +737,38 @@ function independent_publisher_post_has_post_cover_title() {
 	return false; // Default
 }
 
+if ( ! function_exists( 'independent_publisher_content_image_sizes_attr' ) ) :
+	/**
+	 * Set a more accurate sizes attribute for content images
+	 */
+	function independent_publisher_content_image_sizes_attr( $sizes, $size ) {
+		$width = $size[0];
+
+		if ( 700 <= $width ) {
+			$sizes = '(max-width: 500px) calc(100vw - 40px), (max-width: 780px) calc(100vw - 80px), 700px';
+		}
+
+		return $sizes;
+	}
+endif;
+
+add_filter( 'wp_calculate_image_sizes', 'independent_publisher_content_image_sizes_attr', 10, 2 );
+
+if ( ! function_exists( 'independent_publisher_post_thumbnail_sizes_attr' ) ) :
+	/**
+	 * Set a more accurate sizes attribute for full width featured images
+	 */
+	function independent_publisher_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+		if ( independent_publisher_has_full_width_featured_image() ) {
+			$attr['sizes'] = '100vw';
+		}
+
+		return $attr;
+	}
+endif;
+
+add_filter( 'wp_get_attachment_image_attributes', 'independent_publisher_post_thumbnail_sizes_attr', 10, 3 );
+
 
 /**
  * Returns true if Enable Page Load Progress Bar option is enabled

--- a/functions.php
+++ b/functions.php
@@ -769,6 +769,40 @@ endif;
 
 add_filter( 'wp_get_attachment_image_attributes', 'independent_publisher_post_thumbnail_sizes_attr', 10, 3 );
 
+if ( ! function_exists( 'independent_publisher_header_image_tag' ) ) :
+	/**
+	 * Set a more accurate sizes attribute for custom header images
+	 */
+	function independent_publisher_header_image_tag( $html, $header, $attr ) {
+		if ( isset( $attr['class'] ) && isset( $attr['sizes'] ) ) {
+			$old_class = '';
+			$new_sizes = '';
+
+			switch ( $attr['class'] ) {
+				case 'site-master-logo':
+					$old_class = $attr['class'];
+					$new_sizes = '48px';
+					break;
+				case 'site-logo':
+					$old_class = $attr['class'];
+					$new_sizes = '(max-width: 500px) 70px, 100px';
+					break;
+			}
+
+			if ( $old_class ) {
+				$html = str_replace( 'class="' . $old_class . '"', 'class="no-grav"', $html );
+			}
+			if ( $new_sizes ) {
+				$html = str_replace( 'sizes="' . $attr['sizes'] . '"', 'sizes="' . $new_sizes . '"', $html );
+			}
+		}
+
+		return $html;
+	}
+endif;
+
+add_filter( 'get_header_image_tag', 'independent_publisher_header_image_tag', 10, 3 );
+
 
 /**
  * Returns true if Enable Page Load Progress Bar option is enabled

--- a/header.php
+++ b/header.php
@@ -30,7 +30,11 @@
 	<div class="site-master-logo">
 		<?php if ( get_header_image() ) : ?>
 			<a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home">
-				<img class="no-grav" src="<?php echo esc_url( get_header_image() ); ?>" height="<?php echo absint( get_custom_header()->height ); ?>" width="<?php echo absint( get_custom_header()->width ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" />
+				<?php if ( function_exists( 'the_header_image_tag' ) ) : ?>
+					<?php the_header_image_tag( array( 'class' => 'site-master-logo' ) ); ?>
+				<?php else : ?>
+					<img class="no-grav" src="<?php echo esc_url( get_header_image() ); ?>" height="<?php echo absint( get_custom_header()->height ); ?>" width="<?php echo absint( get_custom_header()->width ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" />
+				<?php endif; ?>
 			</a>
 		<?php endif; ?>
 	</div>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -460,7 +460,11 @@ if ( !function_exists( 'independent_publisher_site_info' ) ) :
 		?>
 		<?php if ( get_header_image() ) : ?>
 			<a class="site-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home">
-				<img class="no-grav" src="<?php echo esc_url( get_header_image() ); ?>" height="<?php echo absint( get_custom_header()->height ); ?>" width="<?php echo absint( get_custom_header()->width ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" />
+				<?php if ( function_exists( 'the_header_image_tag' ) ) : ?>
+					<?php the_header_image_tag( array( 'class' => 'site-logo' ) ); ?>
+				<?php else : ?>
+					<img class="no-grav" src="<?php echo esc_url( get_header_image() ); ?>" height="<?php echo absint( get_custom_header()->height ); ?>" width="<?php echo absint( get_custom_header()->width ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" />
+				<?php endif; ?>
 			</a>
 		<?php endif; ?>
 		<div class="site-title">
@@ -490,7 +494,11 @@ if ( !function_exists( 'independent_publisher_posted_author_card' ) ) :
 
 		<?php if ( ( !$show_avatars || $show_avatars === 0 ) && !independent_publisher_is_multi_author_mode() && get_header_image() ) : ?>
 			<a class="site-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home">
-				<img class="no-grav" src="<?php echo esc_url( get_header_image() ); ?>" height="<?php echo absint( get_custom_header()->height ); ?>" width="<?php echo absint( get_custom_header()->width ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" />
+				<?php if ( function_exists( 'the_header_image_tag' ) ) : ?>
+					<?php the_header_image_tag( array( 'class' => 'site-logo' ) ); ?>
+				<?php else : ?>
+					<img class="no-grav" src="<?php echo esc_url( get_header_image() ); ?>" height="<?php echo absint( get_custom_header()->height ); ?>" width="<?php echo absint( get_custom_header()->width ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" />
+				<?php endif; ?>
 			</a>
 		<?php else: ?>
 			<a class="site-logo" href="<?php echo get_author_posts_url( get_the_author_meta( 'ID', $post_author_id ) ); ?>">


### PR DESCRIPTION
These changes work with the built-in [responsive image functionality added in WordPress 4.4](https://make.wordpress.org/core/2015/11/10/responsive-images-in-wordpress-4-4/), to allow browsers to download smaller images when possible.

These changes affect:
* Content images
* Featured images
* Post covers (both "regular" and with post titles overlaid on top)
* Custom header image

These changes are modelled after similar code in the [Twenty Sixteen](https://github.com/WordPress/twentysixteen/blob/6f1f3affcd3dbd2a1bccfefbf7b0e3a47d39873b/functions.php#L360-L405) and [Twenty Seventeen](https://github.com/WordPress/twentyseventeen/blob/fa09211f54799dd03e8acda9d19108aafb1a8c77/functions.php#L324-L370) themes. (Current code for these themes are slightly different than their GitHub versions, but its much easier to link to the GitHub versions :laughing:)

I've tried to be as backwards-compatible as possible (both with older versions of WordPress and with IE<9) but TBH I've only tested these changes with the latest browsers and WP (4.9.8).