### PR TITLE
Fixes bug where webmentions were hidden when comments are disabled

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -95,7 +95,7 @@ if ( post_password_required() ) {
 			<div id="commentform-bottom"></div> <!-- do not remove; used by jQuery to move the comment reply form here -->
 		<?php endif; ?>
 
-		<?php if ( independent_publisher_comment_count_mentions() ) { // If we have mentions, let's show them ?>
+		<?php if ( independent_publisher_comment_count_mentions() && !independent_publisher_hide_mentions() ) { // If we have mentions, let's show them ?>
 			<div id="webmentions" class="mentions-list">
 				<h3><?php echo apply_filters( 'independent_publisher_webmentions_title', __( 'Webmentions', 'independent-publisher' ) ); ?></h3>
 				<?php independent_publisher_mentions(); ?>

--- a/content.php
+++ b/content.php
@@ -113,7 +113,7 @@
 		<?php $separator = apply_filters( 'independent_publisher_entry_meta_separator', '|' ); ?>
 
 		<?php /* Show webmentions link only when post is not password-protected AND pings open AND there are mentions on this post */ ?>
-		<?php if ( !post_password_required() && pings_open() && independent_publisher_comment_count_mentions() ) : ?>
+		<?php if ( !post_password_required() && pings_open() && independent_publisher_comment_count_mentions() && !independent_publisher_hide_mentions() ) : ?>
 			<?php $mention_count = independent_publisher_comment_count_mentions(); ?>
 			<?php $mention_label = (independent_publisher_comment_count_mentions() > 1 ? __( 'Webmentions', 'independent-publisher' ) : __( 'Webmention', 'independent-publisher' ) ); ?>
 			<span class="mentions-link"><a href="<?php the_permalink(); ?>#webmentions"><?php echo $mention_count . ' ' . $mention_label; ?></a></span><span class="sep"><?php echo (comments_open() && !independent_publisher_hide_comments()) ?  ' '.$separator : '' ?></span>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -793,6 +793,15 @@ if ( !function_exists( 'independent_publisher_hide_comments' ) ):
 	}
 endif;
 
+if ( !function_exists( 'independent_publisher_hide_mentions' ) ):
+	/**
+	 * Determines if webmentions should be hidden altogether.
+	 */
+	function independent_publisher_hide_mentions() {
+		return false;
+	}
+endif;
+
 if ( !function_exists( 'independent_publisher_footer_credits' ) ):
 	/**
 	 * Echoes the theme footer credits. Overriding this function in a Child Theme also

--- a/page.php
+++ b/page.php
@@ -21,10 +21,10 @@ get_header(); ?>
 				<?php get_template_part( 'content', 'page' ); ?>
 
 				<?php
-				// If comments are open or we have at least one comment, load up the comment template
-				if ( comments_open() || '0' != get_comments_number() && !independent_publisher_hide_comments() ) :
+				if ( ( comments_open() || '0' != get_comments_number() && !independent_publisher_hide_comments() ) ||
+				( independent_publisher_comment_count_mentions() > 0 && !independent_publisher_hide_mentions() ) ) {
 					comments_template( '', true );
-				endif;
+				}
 				?>
 
 			<?php endwhile; // end of the loop. ?>

--- a/page.php
+++ b/page.php
@@ -21,6 +21,9 @@ get_header(); ?>
 				<?php get_template_part( 'content', 'page' ); ?>
 
 				<?php
+				// If comments are open or we have at least one comment and comments are not hidden, or
+				//   if we have webmentions and webmentions are not hidden, 
+				//     load up the comment template
 				if ( ( comments_open() || '0' != get_comments_number() && !independent_publisher_hide_comments() ) ||
 				( independent_publisher_comment_count_mentions() > 0 && !independent_publisher_hide_mentions() ) ) {
 					comments_template( '', true );

--- a/single.php
+++ b/single.php
@@ -16,8 +16,11 @@ get_header(); ?>
 				<?php get_template_part( 'content', 'single' ); ?>
 
 				<?php
-				// If comments are open or we have at least one comment, load up the comment template
-				if ( comments_open() || '0' != get_comments_number() && !independent_publisher_hide_comments() ) {
+				// If comments are open or we have at least one comment and comments are not hidden, or
+				//   if we have webmentions and webmentions are not hidden, 
+				//     load up the comment template
+				if ( ( comments_open() || '0' != get_comments_number() && !independent_publisher_hide_comments() ) ||
+						( independent_publisher_comment_count_mentions() > 0 && !independent_publisher_hide_mentions() ) ) {
 					comments_template( '', true );
 				}
 				?>


### PR DESCRIPTION
Fixes bug where webmentions were hidden when comments are disabled.

Adds template tag `independent_publisher_hide_mentions()`.

Fixes https://github.com/raamdev/independent-publisher/issues/319