### PR TITLE
Output CSS generated by Customizer inline

### DIFF
--- a/css/customizer.css.php
+++ b/css/customizer.css.php
@@ -1,8 +1,0 @@
-<?php
-/*
- * Outputs Customizer CSS for use on the front-end
- *
- * See inc/customizer.php
- */
-header("Content-type: text/css; charset: UTF-8");
-IndependentPublisher_Customize::header_output();

--- a/functions.php
+++ b/functions.php
@@ -282,30 +282,32 @@ if ( ! function_exists( 'independent_publisher_stylesheet' ) ) :
 	}
 endif;
 
-/*
- * Loads the PHP file that generates the Customizer CSS for the front-end
- */
-function independent_publisher_customizer_css() {
-	require( get_template_directory() . '/css/customizer.css.php' );
-	wp_die();
-}
+if ( ! function_exists( 'independent_publisher_stylesheet' ) ) :
+	/**
+	* Add the Customizer CSS styles inline
+	*/
+	function independent_publisher_customizer_styles_cache() {
+	        global $wp_customize;
 
-/*
- * Enqueue the AJAX call to the dynamic Customizer CSS
- * See http://codex.wordpress.org/AJAX_in_Plugins
- */
-function independent_publisher_customizer_stylesheet() {
-	wp_enqueue_style( 'customizer', admin_url( 'admin-ajax.php' ) . '?action=independent_publisher_customizer_css', array(), '1.7' );
+	        // Check we're not on the Customizer.
+	        // If we're on the customizer then DO NOT cache the results.
+	        if ( ! isset( $wp_customize ) ) {
 
-}
+	                // Get the theme_mod from the database
+	                $data = get_theme_mod( 'independent_publisher_customizer_styles', false );
 
-add_action( 'wp_ajax_independent_publisher_customizer_css', 'independent_publisher_customizer_css' );
-add_action( 'wp_ajax_nopriv_independent_publisher_customizer_css', 'independent_publisher_customizer_css' );
+	                // If the theme_mod does not exist, then create it.
+	                if ( $data == false ) {
+	                        // Initialize the theme_mod.
+	                        set_theme_mod( 'independent_publisher_customizer_styles', null );
+	                }
 
-/*
- * IMPORTANT: Customizer CSS *must* be called _after_ the main stylesheet,
- * to ensure that customizer-modified styles override the defaults.
- */
+	                // Add the CSS inline.
+	                wp_add_inline_style( 'independent-publisher-style', $data );
+	        }
+	}
+endif;
+
 if( is_rtl() ) {
 	add_action( 'init', 'independent_publisher_remove_locale_stylesheet' );
 	add_action( 'wp_enqueue_scripts', 'independent_publisher_stylesheet_rtl' );
@@ -313,7 +315,11 @@ if( is_rtl() ) {
 	add_action( 'wp_enqueue_scripts', 'independent_publisher_stylesheet' );
 }
 
-add_action( 'wp_enqueue_scripts', 'independent_publisher_customizer_stylesheet' );
+/*
+ * IMPORTANT: Customizer CSS *must* be called _after_ the main stylesheet (above),
+ * to ensure that customizer-modified styles override the defaults.
+ */
+add_action( 'wp_enqueue_scripts', 'independent_publisher_customizer_styles_cache' );
 
 if ( ! function_exists( 'independent_publisher_wp_fullscreen_title_editor_style' ) ) :
 	/**

--- a/functions.php
+++ b/functions.php
@@ -282,7 +282,7 @@ if ( ! function_exists( 'independent_publisher_stylesheet' ) ) :
 	}
 endif;
 
-if ( ! function_exists( 'independent_publisher_stylesheet' ) ) :
+if ( ! function_exists( 'independent_publisher_customizer_styles_cache' ) ) :
 	/**
 	* Add the Customizer CSS styles inline
 	*/

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -435,90 +435,94 @@ class IndependentPublisher_Customize {
 	}
 
 	/**
-	 * This will output any custom styles configured by the Theme Customizer
+	 * Saves the custom CSS based on Theme Customizer options to a theme mod
 	 *
-	 * This is used by css/customizer.css.php
+	 * This is used by independent_publisher_customizer_styles_cache() in functions.php
 	 *
+	 * @see independent_publisher_customizer_styles_cache()
 	 * @since Independent Publisher 1.0
 	 */
-	public static function header_output() {
+    public static function independent_publisher_save_customizer_css_theme_mod() {
+		$css = '';
+
 		/* Background Color */
 
-		self::generate_css( '.site', 'background-color', 'background_color', '#' );
+		$css .= self::generate_css( '.site', 'background-color', 'background_color', '#' );
 
 		/* Comment Form Background Color */
 
-		self::generate_css( '.comment-respond', 'background-color', 'comment_form_background_color' );
-		self::generate_css( '.comment-respond', 'color', 'comment_form_text_color' );
+		$css .= self::generate_css( '.comment-respond', 'background-color', 'comment_form_background_color' );
+		$css .= self::generate_css( '.comment-respond', 'color', 'comment_form_text_color' );
 
 		/* Text Color */
 
-		self::generate_css( 'body,input,select,textarea', 'color', 'text_color' );
-		self::generate_css( '.format-aside .entry-content a, .format-aside .entry-content a:hover, .format-aside .entry-content a:visited, .format-aside .entry-content a:active, .format-aside .entry-content a:focus', 'color', 'text_color' );
-		self::generate_css( '.format-quote .entry-content a, .format-quote .entry-content a:hover, .format-quote .entry-content a:visited, .format-quote .entry-content a:active, .format-quote .entry-content a:focus', 'color', 'text_color' );
-		self::generate_css( '.post-excerpts .format-standard .entry-content a, .post-excerpts .format-standard .entry-content a:focus, .post-excerpts .format-standard .entry-content a:hover, .post-excerpts .format-standard .entry-content a:active, .post-excerpts .format-standard .entry-content a:visited', 'color', 'text_color' );
-		self::generate_css( '.post-excerpts .format-chat .entry-content a, .post-excerpts .format-chat .entry-content a:focus, .post-excerpts .format-chat .entry-content a:hover, .post-excerpts .format-chat .entry-content a:active, .post-excerpts .format-chat .entry-content a:visited', 'color', 'text_color' );
-		self::generate_css( '.post-excerpts .format-standard .entry-summary a, .post-excerpts .format-standard .entry-summary a:focus, .post-excerpts .format-standard .entry-summary a:hover, .post-excerpts .format-standard .entry-summary a:active, .post-excerpts .format-standard .entry-summary a:visited', 'color', 'text_color' );
-		self::generate_css( '.post-excerpts .format-chat .entry-summary a, .post-excerpts .format-chat .entry-summary a:focus, .post-excerpts .format-chat .entry-summary a:hover, .post-excerpts .format-chat .entry-summary a:active, .post-excerpts .format-chat .entry-summary a:visited', 'color', 'text_color' );
+		$css .= self::generate_css( 'body,input,select,textarea', 'color', 'text_color' );
+		$css .= self::generate_css( '.format-aside .entry-content a, .format-aside .entry-content a:hover, .format-aside .entry-content a:visited, .format-aside .entry-content a:active, .format-aside .entry-content a:focus', 'color', 'text_color' );
+		$css .= self::generate_css( '.format-quote .entry-content a, .format-quote .entry-content a:hover, .format-quote .entry-content a:visited, .format-quote .entry-content a:active, .format-quote .entry-content a:focus', 'color', 'text_color' );
+		$css .= self::generate_css( '.post-excerpts .format-standard .entry-content a, .post-excerpts .format-standard .entry-content a:focus, .post-excerpts .format-standard .entry-content a:hover, .post-excerpts .format-standard .entry-content a:active, .post-excerpts .format-standard .entry-content a:visited', 'color', 'text_color' );
+		$css .= self::generate_css( '.post-excerpts .format-chat .entry-content a, .post-excerpts .format-chat .entry-content a:focus, .post-excerpts .format-chat .entry-content a:hover, .post-excerpts .format-chat .entry-content a:active, .post-excerpts .format-chat .entry-content a:visited', 'color', 'text_color' );
+		$css .= self::generate_css( '.post-excerpts .format-standard .entry-summary a, .post-excerpts .format-standard .entry-summary a:focus, .post-excerpts .format-standard .entry-summary a:hover, .post-excerpts .format-standard .entry-summary a:active, .post-excerpts .format-standard .entry-summary a:visited', 'color', 'text_color' );
+		$css .= self::generate_css( '.post-excerpts .format-chat .entry-summary a, .post-excerpts .format-chat .entry-summary a:focus, .post-excerpts .format-chat .entry-summary a:hover, .post-excerpts .format-chat .entry-summary a:active, .post-excerpts .format-chat .entry-summary a:visited', 'color', 'text_color' );
 
 		/* Link Color */
 
-		self::generate_css( 'a, a:visited, a:hover, a:focus, a:active', 'color', 'link_color' );
-		self::generate_css( '.enhanced-excerpts .enhanced-excerpt-read-more a, .enhanced-excerpts .enhanced-excerpt-read-more a:hover', 'color', 'link_color' );
-		self::generate_css( '.post-excerpts .sticky.format-standard .entry-content a, .post-excerpts .sticky.format-standard .entry-content a:focus, .post-excerpts .sticky.format-standard .entry-content a:hover, .post-excerpts .sticky.format-standard .entry-content a:active, .post-excerpts .sticky.format-standard .entry-content a:visited', 'color', 'link_color' );
-		self::generate_css( '.post-excerpts .format-standard.show-full-content-first-post .entry-content a', 'color', 'link_color' );
-		self::generate_css( '.post-excerpts .format-standard .entry-content a.moretag', 'color', 'link_color' );
-		self::generate_css( '.post-excerpts .format-standard .entry-content a.more-link', 'color', 'link_color' );
-		self::generate_css( '.post-excerpts .sticky.format-standard .entry-summary a, .post-excerpts .sticky.format-standard .entry-summary a:focus, .post-excerpts .sticky.format-standard .entry-summary a:hover, .post-excerpts .sticky.format-standard .entry-summary a:active, .post-excerpts .sticky.format-standard .entry-summary a:visited', 'color', 'link_color' );
-		self::generate_css( '.post-excerpts .format-standard.show-full-content-first-post .entry-summary a', 'color', 'link_color' );
-		self::generate_css( '.post-excerpts .format-standard .entry-summary a.moretag', 'color', 'link_color' );
-		self::generate_css( '.post-excerpts .format-standard .entry-summary a.more-link', 'color', 'link_color' );
-		self::generate_css( '.read-more a, .read-more a:hover', 'color', 'link_color' );
-		self::generate_css( '.entry-title a:hover', 'color', 'link_color' );
-		self::generate_css( '.entry-meta a:hover', 'color', 'link_color' );
-		self::generate_css( '.site-footer a:hover', 'color', 'link_color' );
-		self::generate_css( 'blockquote', 'border-color', 'link_color' );
-		self::generate_css( '#infinite-footer .blog-credits a, #infinite-footer .blog-credits a:hover', 'color', 'link_color' );
-		self::generate_css( '#nprogress .bar', 'background', 'link_color' );
-		self::generate_css( '#nprogress .spinner-icon', 'border-top-color', 'link_color' );
-		self::generate_css( '#nprogress .spinner-icon', 'border-left-color', 'link_color' );
-		self::generate_css( '#nprogress .peg', 'box-shadow', 'link_color', '', '', true, '%1$s { %2$s:0 0 10px %3$s, 0 0 5px %3$s; }' );
+		$css .= elf::generate_css( 'a, a:visited, a:hover, a:focus, a:active', 'color', 'link_color' );
+		$css .= self::generate_css( '.enhanced-excerpts .enhanced-excerpt-read-more a, .enhanced-excerpts .enhanced-excerpt-read-more a:hover', 'color', 'link_color' );
+		$css .= self::generate_css( '.post-excerpts .sticky.format-standard .entry-content a, .post-excerpts .sticky.format-standard .entry-content a:focus, .post-excerpts .sticky.format-standard .entry-content a:hover, .post-excerpts .sticky.format-standard .entry-content a:active, .post-excerpts .sticky.format-standard .entry-content a:visited', 'color', 'link_color' );
+		$css .= self::generate_css( '.post-excerpts .format-standard.show-full-content-first-post .entry-content a', 'color', 'link_color' );
+		$css .= self::generate_css( '.post-excerpts .format-standard .entry-content a.moretag', 'color', 'link_color' );
+		$css .= self::generate_css( '.post-excerpts .format-standard .entry-content a.more-link', 'color', 'link_color' );
+		$css .= self::generate_css( '.post-excerpts .sticky.format-standard .entry-summary a, .post-excerpts .sticky.format-standard .entry-summary a:focus, .post-excerpts .sticky.format-standard .entry-summary a:hover, .post-excerpts .sticky.format-standard .entry-summary a:active, .post-excerpts .sticky.format-standard .entry-summary a:visited', 'color', 'link_color' );
+		$css .= self::generate_css( '.post-excerpts .format-standard.show-full-content-first-post .entry-summary a', 'color', 'link_color' );
+		$css .= self::generate_css( '.post-excerpts .format-standard .entry-summary a.moretag', 'color', 'link_color' );
+		$css .= self::generate_css( '.post-excerpts .format-standard .entry-summary a.more-link', 'color', 'link_color' );
+		$css .= self::generate_css( '.read-more a, .read-more a:hover', 'color', 'link_color' );
+		$css .= self::generate_css( '.entry-title a:hover', 'color', 'link_color' );
+		$css .= self::generate_css( '.entry-meta a:hover', 'color', 'link_color' );
+		$css .= self::generate_css( '.site-footer a:hover', 'color', 'link_color' );
+		$css .= self::generate_css( 'blockquote', 'border-color', 'link_color' );
+		$css .= self::generate_css( '#infinite-footer .blog-credits a, #infinite-footer .blog-credits a:hover', 'color', 'link_color' );
+		$css .= self::generate_css( '#nprogress .bar', 'background', 'link_color' );
+		$css .= self::generate_css( '#nprogress .spinner-icon', 'border-top-color', 'link_color' );
+		$css .= self::generate_css( '#nprogress .spinner-icon', 'border-left-color', 'link_color' );
+		$css .= self::generate_css( '#nprogress .peg', 'box-shadow', 'link_color', '', '', true, '%1$s { %2$s:0 0 10px %3$s, 0 0 5px %3$s; }' );
 
-		self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s:%3$s; /* Old browsers */ }' );
-		self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -moz-linear-gradient(top, %3$s 60%%, %3$s 100%%); /* FF3.6+ */ }' );
-		self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -webkit-gradient(linear, left top, left bottom, color-stop(60%%, %3$s), color-stop(100%%, %3$s)); /* Chrome,Safari4+ */ }' );
-		self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -webkit-linear-gradient(top, %3$s 60%%, %3$s 100%%); /* Chrome10+,Safari5.1+ */ }' );
-		self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -o-linear-gradient(top, %3$s 60%%, %3$s 100%%); /* Opera 11.10+ */ }' );
-		self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -ms-linear-gradient(top, %3$s 60%%, %3$s 100%%); /* IE10+ */ }' );
-		self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: linear-gradient(top, %3$s 60%%, %3$s 100%%); /* W3C */ }' );
+		$css .= self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s:%3$s; /* Old browsers */ }' );
+		$css .= self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -moz-linear-gradient(top, %3$s 60%%, %3$s 100%%); /* FF3.6+ */ }' );
+		$css .= self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -webkit-gradient(linear, left top, left bottom, color-stop(60%%, %3$s), color-stop(100%%, %3$s)); /* Chrome,Safari4+ */ }' );
+		$css .= self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -webkit-linear-gradient(top, %3$s 60%%, %3$s 100%%); /* Chrome10+,Safari5.1+ */ }' );
+		$css .= self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -o-linear-gradient(top, %3$s 60%%, %3$s 100%%); /* Opera 11.10+ */ }' );
+		$css .= self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: -ms-linear-gradient(top, %3$s 60%%, %3$s 100%%); /* IE10+ */ }' );
+		$css .= self::generate_css( 'button, html input[type="button"], input[type="reset"], input[type="submit"], button:hover, html input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover', 'background', 'link_color', '', '', true, '%1$s { %2$s: linear-gradient(top, %3$s 60%%, %3$s 100%%); /* W3C */ }' );
 
 		/* Header Text Color */
 
-		self::generate_css( '.site-published', 'color', 'header_text_color' );
-		self::generate_css( '.site-title a', 'color', 'header_text_color' );
-		self::generate_css( 'h1,h2,h3,h4,h5,h6', 'color', 'header_text_color' );
-		self::generate_css( '.entry-title a', 'color', 'header_text_color' );
-		self::generate_css( '.author .archive-title a', 'color', 'header_text_color' );
-		self::generate_css( '.author .archive-title a', 'color', 'header_text_color' );
+		$css .= self::generate_css( '.site-published', 'color', 'header_text_color' );
+		$css .= self::generate_css( '.site-title a', 'color', 'header_text_color' );
+		$css .= self::generate_css( 'h1,h2,h3,h4,h5,h6', 'color', 'header_text_color' );
+		$css .= self::generate_css( '.entry-title a', 'color', 'header_text_color' );
+		$css .= self::generate_css( '.author .archive-title a', 'color', 'header_text_color' );
+		$css .= self::generate_css( '.author .archive-title a', 'color', 'header_text_color' );
 
 		/* Primary Meta Text Color */
 
-		self::generate_css( '.site-description', 'color', 'primary_meta_text_color' );
-		self::generate_css( '.site-published-date a, .site-published-date a:hover, .site-published-date a:visited, .site-published-date a:focus, .site-published-date a:active', 'color', 'primary_meta_text_color' );
-		self::generate_css( '.pinglist-title,.taglist-title,.pinglist li::after', 'color', 'primary_meta_text_color' );
+		$css .= self::generate_css( '.site-description', 'color', 'primary_meta_text_color' );
+		$css .= self::generate_css( '.site-published-date a, .site-published-date a:hover, .site-published-date a:visited, .site-published-date a:focus, .site-published-date a:active', 'color', 'primary_meta_text_color' );
+		$css .= self::generate_css( '.pinglist-title,.taglist-title,.pinglist li::after', 'color', 'primary_meta_text_color' );
 
 		/* Secondary Meta Text Color */
 
-		self::generate_css( '.comment-form-author label, .comment-form-email label, .comment-form-url label, .comment-form-comment label, .comment-form-subscriptions label, .comment-form-reply-title', 'color', 'secondary_meta_text_color' );
-		self::generate_css( '.entry-title-meta, .entry-title-meta a, .entry-title-meta a:hover, .entry-title-meta a:visited, .entry-title-meta a:focus, .entry-title-meta a:active', 'color', 'secondary_meta_text_color' );
-		self::generate_css( '.entry-meta, .entry-meta a, .entry-meta a:hover', 'color', 'secondary_meta_text_color' );
-		self::generate_css( '.format-aside .entry-format, .format-quote .entry-format, .format-chat .entry-format, .format-status .entry-format, .format-image .entry-format, .format-link .entry-format, .format-gallery .entry-format', 'color', 'secondary_meta_text_color' );
-		self::generate_css( '.comment-meta, .comment-meta a', 'color', 'secondary_meta_text_color' );
-		self::generate_css( '.widget_rss .rss-date, .widget_rss li > cite, .widget_twitter .timesince', 'color', 'secondary_meta_text_color' );
-		self::generate_css( '.site-footer', 'color', 'secondary_meta_text_color' );
-		self::generate_css( '.comment-content.unapproved', 'color', 'secondary_meta_text_color' );
-		self::generate_css( '#infinite-footer .blog-credits', 'color', 'secondary_meta_text_color' );
+		$css .= self::generate_css( '.comment-form-author label, .comment-form-email label, .comment-form-url label, .comment-form-comment label, .comment-form-subscriptions label, .comment-form-reply-title', 'color', 'secondary_meta_text_color' );
+		$css .= self::generate_css( '.entry-title-meta, .entry-title-meta a, .entry-title-meta a:hover, .entry-title-meta a:visited, .entry-title-meta a:focus, .entry-title-meta a:active', 'color', 'secondary_meta_text_color' );
+		$css .= self::generate_css( '.entry-meta, .entry-meta a, .entry-meta a:hover', 'color', 'secondary_meta_text_color' );
+		$css .= self::generate_css( '.format-aside .entry-format, .format-quote .entry-format, .format-chat .entry-format, .format-status .entry-format, .format-image .entry-format, .format-link .entry-format, .format-gallery .entry-format', 'color', 'secondary_meta_text_color' );
+		$css .= self::generate_css( '.comment-meta, .comment-meta a', 'color', 'secondary_meta_text_color' );
+		$css .= self::generate_css( '.widget_rss .rss-date, .widget_rss li > cite, .widget_twitter .timesince', 'color', 'secondary_meta_text_color' );
+		$css .= self::generate_css( '.site-footer', 'color', 'secondary_meta_text_color' );
+		$css .= self::generate_css( '.comment-content.unapproved', 'color', 'secondary_meta_text_color' );
+		$css .= self::generate_css( '#infinite-footer .blog-credits', 'color', 'secondary_meta_text_color' );
 
+		set_theme_mod( 'independent_publisher_customizer_styles', $data );
 	}
 
 	/**
@@ -616,6 +620,9 @@ function independent_publisher_sanitize_select_excerpt_options( $input ) {
 		return '';
 	}
 }
+
+// Update theme mod containing custom CSS
+add_action( 'customize_save_after', array( 'IndependentPublisher_Customize', 'independent_publisher_save_customizer_css_theme_mod' ) );
 
 // Setup the Theme Customizer settings and controls...
 add_action( 'customize_register', array( 'IndependentPublisher_Customize', 'register' ) );


### PR DESCRIPTION
**Note: This is a work in progress.** 

---

The current method of outputting CSS generated by the theme options in the Customizer uses Admin AJAX. This is not compatible with caching and is an unnecessary performance bottleneck.

Instead of dynamically generating the needed CSS on-the-fly via Admin AJAX, let's store the generated CSS in a theme mod, then output the CSS inline via `wp_add_inline_style()`. 

---

Addresses #305. 