### PR TITLE
Fix PHP 8 warning: Undefined array key "background_color"

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -561,7 +561,10 @@ class IndependentPublisher_Customize {
 	 */
 	public static function generate_css( $selector, $style, $mod_name, $prefix = '', $postfix = '', $echo = true, $format = '%1$s { %2$s:%3$s; }' ) {
 		$return            = '';
-		$mod               = get_theme_mod( $mod_name, self::$default_colors[$mod_name] );
+		// Get the default value if available, or empty string if not
+		$default = isset( self::$default_colors[ $mod_name ] ) ? self::$default_colors[ $mod_name ] : '';
+		$mod               = get_theme_mod( $mod_name, $default );
+
 		if ( !empty( $mod ) ) {
 			$return = sprintf(
 				$format . "\n",


### PR DESCRIPTION
Fixes `PHP Warning: Undefined array key "background_color" in wp-content/themes/independent-publisher/inc/customizer.php on line 563`.

Fixes https://github.com/raamdev/independent-publisher/issues/326

Props @jan-vandenberg